### PR TITLE
Fix draw animation + remove autofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v5.4.1
+
+- Fix visual bug: when a value was animated 2 times in a row, it broke the animation rhythm. Now, a value can be animated only once.
+- Remove autofocus of new value input, because it was annoying for mobile users.
+
 ## v5.4.0
 
 - Add "About" page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plouf-plouf.fr",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": false,
   "license": "MPL-2.0",
   "scripts": {

--- a/src/components/CreateDraw/AddValueForm/AddValueInput/AddValueInput.tsx
+++ b/src/components/CreateDraw/AddValueForm/AddValueInput/AddValueInput.tsx
@@ -74,7 +74,6 @@ const AddValueInput: React.FC<Props> = ({ startDrawAction, addValueAction }) => 
         data-cy="AddValueForm_textInput"
         type="text"
         className={styles.textInput}
-        autoFocus
         ref={inputElement}
         placeholder="Ex: Paul [↵] Margot [↵]"
         onChange={handleInputChange}

--- a/src/redux/features/animation/sagas.ts
+++ b/src/redux/features/animation/sagas.ts
@@ -44,10 +44,15 @@ export function* startAnimation(): Generator {
   }
   // If there is more than MAX_VALUES_TO_ANIMATE values, we animate MAX_VALUES_TO_ANIMATE randomly picked values
   else {
+    // We create a list of indices of candidates values to be animated
+    const indices = Object.keys(state.draw.draw.values)
+    indices.splice(state.draw.draw.drawnIndex, 1) // We exclude the result from the candidates
+
     for (let i = 0; i < MAX_VALUES_TO_ANIMATE - 1; i++) {
-      const index = Math.floor(Math.random() * nbValues)
+      const index = Math.floor(Math.random() * indices.length) // We pick a value from the (remaining) candidates
       yield delay(DELAY_MS)
-      yield put(actions.animateValue(index))
+      yield put(actions.animateValue(Number(indices[index])))
+      indices.splice(index, 1) // If a value has been chosen to be animated, we remove it from the candidates
     }
   }
 


### PR DESCRIPTION
### v5.4.1

- Fix visual bug: when a value was animated 2 times in a row, it broke the animation rhythm. Now, a value can be animated only once.
- Remove autofocus of new value input, because it was annoying for mobile users.