### PR TITLE
feat(i18n): move all hard-coded string in a localized files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,13 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   swcMinify: true,
+  webpack: config => {
+    config.module.rules.push({
+      test: /\.ya?ml$/,
+      use: 'yaml-loader',
+    })
+    return config
+  },
 }
 
 module.exports = withOffline(nextConfig)

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
     "@types/react": "18.3.10",
     "@types/redux-logger": "3.0.13",
     "classnames": "2.5.1",
+    "i18next": "^25.3.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "next": "14.2.13",
     "next-offline": "5.0.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-i18next": "^15.6.0",
     "react-redux": "9.1.2",
     "redux-logger": "3.0.6",
     "typescript": "5.3.3",
@@ -45,6 +48,8 @@
     "husky": "9.1.6",
     "lint-staged": "15.2.10",
     "prettier": "3.3.3",
-    "start-server-and-test": "2.0.8"
-  }
+    "start-server-and-test": "2.0.8",
+    "yaml-loader": "^0.8.1"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,90 +1,31 @@
-import styles from './About.module.css'
+import { Trans } from 'react-i18next'
 
+import styles from './About.module.css'
+type HTMLAnchorElementProps = React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>
+
+const Link = (props: HTMLAnchorElementProps) => (
+  <u>
+    <a {...props} title="a link" target="_blank" rel="noopener noreferrer" />
+  </u>
+)
 const About = () => {
   return (
     <div className={styles.container}>
-      <h2>À propos</h2>
-      <p>
-        <b>http://plouf-plouf.fr</b> est un site entièrement gratuit, sans aucune pub ni aucun
-        tracking des utilisateurs. Les données du tirage au sort ne sont à aucun moment stockées sur
-        le serveur. En effet, lors du partage d&apos;un tirage au sort, les données du tirage sont
-        stockées directement et uniquement dans l&apos;URL générée.
-      </p>
-      <p>
-        <b>
-          Les données des tirages sont strictement confidentielles&nbsp;: ni les auteurs du site, ni
-          les hébergeurs du site n&apos;y ont accès.
-        </b>
-      </p>
-      <p>
-        <b>
-          Si vous partagez le résultat d&apos;un tirage au sort, alors toutes les personnes ayant
-          accès à l&apos;URL du tirage auront accès à toutes les données du tirage.
-        </b>
-      </p>
-      <p>
-        Le site a entièrement été réalisé de manière bénévole par{' '}
-        <u>
-          <a href="https://paulintrognon.fr">Paulin Trognon</a>
-        </u>
-        . Le code source du site est consultable à cette adresse&nbsp;:{' '}
-        <u>
-          <a href="https://github.com/paulintrognon/plouf-plouf">
-            github.com/paulintrognon/plouf-plouf
-          </a>
-        </u>
-        .
-      </p>
-      <h2>Comment ça marche&nbsp;?</h2>
-      <p>
-        Les tirages sont effectuées en local, directement par le navigateur, à l&apos;aide de la
-        méthode <code>Math.random()</code>.
-      </p>
-      <p>
-        Afin de pouvoir partager le tirage et son résultat, une URL est générée contenant les mots
-        ainsi que le résultat au format json, encodé en base 64.
-      </p>
-      <p>
-        Par exemple, pour l&apos;URL{' '}
-        https://plouf-plouf.fr/r#eyJ2IjpbIlBhdWwiLCJNYXJnb3QiXSwiaSI6MX0=-v3, le tirage est encodé
-        dans <code>eyJ2IjpbIlBhdWwiLCJNYXJnb3QiXSwiaSI6MX0=</code>, qui une fois décodé donne&nbsp;:{' '}
-        <code>{'{"v":["Paul","Margot"],"i":1}'}</code>
-      </p>
-      <h2>Conditions Générales d&apos;Utilisation</h2>
-      <p>
-        L&apos;utilisation du site plouf-plouf.fr implique l&apos;acceptation des conditions
-        générales d&apos;utilisation (CGU) suivantes (CGU et mentions légales susceptibles de
-        modification à tout moment, les utilisateurs sont invités à les consulter à chaque
-        utilisation du site).
-      </p>
-      <p>
-        Le site plouf-plouf.fr est supposé accessible en tout instant, pour tous les utilisateurs
-        connectés au serveur, néanmoins des interruptions (volontaires : mise à jour, maintenance
-        technique, etc.) ou involontaires (problèmes hébergeurs, bugs, etc.) peuvent néanmoins
-        survenir.
-      </p>
-      <p>
-        Le site plouf-plouf.fr est un site composé d&apos;un formulaire ayant pour but de générer un
-        tirage au sort. Toutefois, les auteurs ne pourront être tenus responsables
-        d&apos;éventuelles omissions ou inexactitudes dans les résultats et informations fournis.
-        Les données et informations qui peuvent êtres consultées sur le site plouf-plouf.fr évoluent
-        régulièrement et ne peuvent être considérées comme fiables dans le temps.
-      </p>
-      <p>
-        Le site plouf-plouf.fr utilise des technologies web standard (HTML, CSS, JavaScript) et ne
-        pourra être tenu responsable de dommages directs ou indirects liés à l&apos;usage du site.
-        L&apos;utilisateur s&apos;engage à utiliser le site plouf-plouf.fr uniquement avec un
-        matériel récent et des logiciels mis à jour et non modifiés (piratage, virus, etc.). En
-        utilisant le site plouf-plouf.fr, l&apos;hébergeur a l&apos;obligation de recueillir
-        certaines données comme l&apos;adresse IP de l&apos;utilisateur. Noter qu&apos;aucune
-        requête directe demandant nom, prénom, adresse, ou autres données personnelles identifiantes
-        ne sera réalisée sur le site plouf-plouf.fr. Néanmoins, pour certains services proposés par
-        plouf-plouf.fr, l&apos;utilisateur doit rester attentif à ne pas fournir ce type
-        d&apos;informations notamment lorsqu&apos;il procède par lui-même à leur saisie. Le site
-        plouf-plouf.fr propose des liens vers d&apos;autres sites mais n&apos;a pas la capacité de
-        vérifier les contenus mis à jour des sites ainsi visités, et ne pourra être tenu responsable
-        de leur contenu.
-      </p>
+      <Trans
+        components={{
+          Link: <Link />,
+          Heading: <h2>no content</h2>,
+          Paragraph: <p />,
+          Bold: <b />,
+          Underline: <u />,
+          Code: <code />,
+        }}
+        transSupportBasicHtmlNodes={true}
+        i18nKey="about.content_html"
+      />
     </div>
   )
 }

--- a/src/components/BulkAddLink/BulkAddLink.tsx
+++ b/src/components/BulkAddLink/BulkAddLink.tsx
@@ -1,16 +1,18 @@
+import { WithTranslation, withTranslation } from 'react-i18next'
+
 import styles from './BulkAddLink.module.css'
 import A from '../Shared/A/A'
 
-const BulkAddLink = () => {
+const BulkAddLink: React.FC<WithTranslation> = ({ t }) => {
   return (
     <div className={styles.container}>
       <p>ou</p>
       <p>
         <A href="/import" data-cy="BulkAddLink">
-          Importer une liste
+          {t('home.bulk_add_link')}
         </A>
       </p>
     </div>
   )
 }
-export default BulkAddLink
+export default withTranslation()(BulkAddLink)

--- a/src/components/CreateDraw/AddValueForm/AddValueForm.tsx
+++ b/src/components/CreateDraw/AddValueForm/AddValueForm.tsx
@@ -1,18 +1,15 @@
+import { WithTranslation, withTranslation } from 'react-i18next'
+
 import styles from './AddValueForm.module.css'
 import AddValueInput from './AddValueInput/AddValueInput'
 
-const AddValueForm = () => {
+const AddValueForm: React.FC<WithTranslation> = ({ t }) => {
   return (
     <div className={styles.container}>
-      <p className={styles.explanations1}>
-        Ajoutez plusieurs éléments à tirer au sort, puis cliquez sur &quot;Tirer au sort&quot;..
-      </p>
+      <p className={styles.explanations1}>{t('home.form.add_element.help_text')}</p>
       <AddValueInput />
-      <p className={styles.explanations2}>
-        (pour ajouter un élément, inscrivez-le ci-dessus puis cliquez sur le bouton [+] ou sur la
-        touche Entrée)
-      </p>
+      <p className={styles.explanations2}>{t('home.form.add_element.button_help_text')}</p>
     </div>
   )
 }
-export default AddValueForm
+export default withTranslation()(AddValueForm)

--- a/src/components/CreateDraw/AddValueForm/AddValueInput/AddValueInput.tsx
+++ b/src/components/CreateDraw/AddValueForm/AddValueInput/AddValueInput.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './AddValueInput.module.css'
@@ -7,7 +8,7 @@ import { drawSlice } from '../../../../store/features/draw/draw.slice'
 import { RootState } from '../../../../store/store'
 import Button from '../../../Shared/Button/Button'
 
-const AddValueInput = () => {
+const AddValueInput: React.FC<WithTranslation> = ({ t }) => {
   const dispatch = useDispatch()
   const values = useSelector((state: RootState) => state.draw.draw.values)
 
@@ -79,22 +80,22 @@ const AddValueInput = () => {
         type="text"
         className={styles.textInput}
         ref={inputElement}
-        placeholder="Ex: Paul [↵] Margot [↵]"
+        placeholder={t('home.form.add_element.placeholder')}
         onChange={handleInputChange}
         onKeyPress={handleKeyPress}
         value={enteredText}
-        title="Entrez ici un mot ou un nom à tirer au sort."
+        title={t('home.form.add_element.title')}
       />
       <Button
         color="blue"
         data-cy="AddValueForm_addInput"
         className={styles.addInput}
         onClick={handleAdd}
-        title="Cliquez ici pour ajouter une valeur à la liste"
+        title={t('home.form.add_element.button_title')}
       >
         <i className="fa fa-plus" aria-hidden="true" />
       </Button>
     </p>
   )
 }
-export default AddValueInput
+export default withTranslation()(AddValueInput)

--- a/src/components/CreateDraw/ListValues/ListValues.tsx
+++ b/src/components/CreateDraw/ListValues/ListValues.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './ListValues.module.css'
@@ -6,7 +7,7 @@ import { drawSlice } from '../../../store/features/draw/draw.slice'
 import { RootState } from '../../../store/store'
 import Value from '../../Shared/Value/Value'
 
-const ListValues = () => {
+const ListValues: React.FC<WithTranslation> = ({ t }) => {
   const dispatch = useDispatch()
   const values = useSelector((rootState: RootState) => rootState.draw.draw.values)
 
@@ -18,7 +19,7 @@ const ListValues = () => {
   }
 
   const handleReset = (): void => {
-    if (!confirm('Êtes-vous sûr de vouloir tout supprimer ?')) {
+    if (!confirm(t('home.form.reset_button.confirm'))) {
       return
     }
     dispatch(drawSlice.actions.reset())
@@ -39,9 +40,9 @@ const ListValues = () => {
           onClick={handleReset}
           className={styles.resetButton}
           data-cy="ListValues_resetButton"
-          title="Cliquer ici pour recommencer un nouveau tirage de zéro."
+          title={t('home.form.reset_button.title')}
         >
-          Tout supprimer
+          {t('home.form.reset_button.text')}
         </button>
       </div>
       <div className={styles.list}>
@@ -53,4 +54,4 @@ const ListValues = () => {
   )
 }
 
-export default ListValues
+export default withTranslation()(ListValues)

--- a/src/components/CreateDraw/SubmitValues/SubmitValues.tsx
+++ b/src/components/CreateDraw/SubmitValues/SubmitValues.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import styles from './SubmitValues.module.css'
@@ -6,7 +7,7 @@ import { drawValueAndStartAnimation } from '../../../store/features/draw/draw.se
 import { RootState } from '../../../store/store'
 import Button from '../../Shared/Button/Button'
 
-export const SubmitValues = () => {
+export const SubmitValues: React.FC<WithTranslation> = ({ t }) => {
   const values = useSelector((state: RootState) => state.draw.draw.values)
 
   const canSubmit = values.length >= 2
@@ -26,14 +27,14 @@ export const SubmitValues = () => {
         onClick={handleSubmit}
         title={
           !canSubmit
-            ? 'Vous devez inscrire au moins deux valeurs avant de pouvoir tirer au sort.'
-            : 'Lancer le tirage au sort !'
+            ? t('home.form.submit_button.error_message')
+            : t('home.form.submit_button.success_message')
         }
       >
-        Tirer au sort
+        {t('home.form.submit_button.text')}
       </Button>
     </p>
   )
 }
 
-export default SubmitValues
+export default withTranslation()(SubmitValues)

--- a/src/components/DrawResult/ActionButtons/ActionButtons.tsx
+++ b/src/components/DrawResult/ActionButtons/ActionButtons.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames'
 import { useRouter } from 'next/router'
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import styles from './ActionButtons.module.css'
@@ -12,7 +13,7 @@ interface ActionButtonsProps {
   slug: string
   hidden: boolean
 }
-const ActionButtons = ({ slug, hidden }: ActionButtonsProps) => {
+const ActionButtons: React.FC<WithTranslation & ActionButtonsProps> = ({ t, slug, hidden }) => {
   const router = useRouter()
   const draw = useSelector((state: RootState) => state.draw)
 
@@ -32,7 +33,7 @@ const ActionButtons = ({ slug, hidden }: ActionButtonsProps) => {
   return (
     <div className={classnames(styles.main, hidden ? globalStyles.hidden : globalStyles.visible)}>
       <label className={styles.share}>
-        Partager le résultat&nbsp;:
+        {t('result.action_buttons.share')}
         <input
           data-cy="ActionButtons_shareInput"
           type="text"
@@ -49,7 +50,7 @@ const ActionButtons = ({ slug, hidden }: ActionButtonsProps) => {
           onClick={() => router.push('/')}
         >
           <i className={classnames('fa fa-long-arrow-left', styles.icon)} aria-hidden="true"></i>
-          Modifier
+          {t('result.action_buttons.modify')}
         </button>
         <button
           data-cy="ActionButtons_restartButton"
@@ -58,7 +59,7 @@ const ActionButtons = ({ slug, hidden }: ActionButtonsProps) => {
           onClick={() => drawValueAndStartAnimation(draw.draw.values)}
         >
           <i className={classnames('fa fa-random', styles.icon)} aria-hidden="true"></i>
-          Refaire
+          {t('result.action_buttons.redo')}
         </button>
         {draw.draw.values.length > 2 ? (
           <button
@@ -68,11 +69,11 @@ const ActionButtons = ({ slug, hidden }: ActionButtonsProps) => {
             onClick={handleRedoWithoutDrawnValue}
           >
             <i className={classnames('fa fa-eraser', styles.icon)} aria-hidden="true"></i>
-            Refaire sans &quot;{value}&quot;
+            {t('result.action_buttons.redo_without_value', { value })}
           </button>
         ) : null}
       </p>
     </div>
   )
 }
-export default ActionButtons
+export default withTranslation()(ActionButtons)

--- a/src/components/DrawResult/AnimatedValues/AnimatedValues.tsx
+++ b/src/components/DrawResult/AnimatedValues/AnimatedValues.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import styles from './AnimatedValues.module.css'
 import Animation from '../../../store/features/animation/types/Animation.type'
@@ -17,10 +18,14 @@ interface AnimatedValuesProps {
   values: Values
   animation: Animation
 }
-const AnimatedValues = ({ values, animation }: AnimatedValuesProps) => {
+const AnimatedValues: React.FC<WithTranslation & AnimatedValuesProps> = ({
+  t,
+  values,
+  animation,
+}) => {
   const ref = useRef<HTMLDivElement>(null)
   if (!values) {
-    return <div>Pas de valeurs.</div>
+    return <div>{t('result.animated_values.no_values')}</div>
   }
   const scrollIntoView = Boolean(ref.current && !isScrolledIntoView(ref.current))
   return (
@@ -42,4 +47,4 @@ const AnimatedValues = ({ values, animation }: AnimatedValuesProps) => {
     </div>
   )
 }
-export default AnimatedValues
+export default withTranslation()(AnimatedValues)

--- a/src/components/DrawResult/DrawResult.tsx
+++ b/src/components/DrawResult/DrawResult.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head'
 import Image from 'next/image'
 import React, { useEffect } from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import ActionButtons from './ActionButtons/ActionButtons'
@@ -15,13 +16,14 @@ export interface DrawResultProps {
   slug: string
 }
 
-export const DrawResult = ({ slug }: DrawResultProps) => {
+export const DrawResult: React.FC<WithTranslation & DrawResultProps> = ({ t, slug }) => {
   const dispatch = useDispatch()
   const draw = useSelector((state: RootState) => state.draw)
   const animation = useSelector((state: RootState) => state.animation)
 
   useEffect(() => {
     ;(async () => {
+      if (draw.hasError) return
       // Load draw from slug
       if (draw.draw.values.length === 0) {
         dispatch(drawSlice.actions.loadFromSlug(slug))
@@ -40,7 +42,7 @@ export const DrawResult = ({ slug }: DrawResultProps) => {
         <p>
           <Image src="/sad.jpg" alt="Sad cat drawing" width={250} height={161} />
         </p>
-        <p>Impossible de charger le tirage au sort à partir de cette url...</p>
+        <p>{t('result.loading_error')}</p>
       </div>
     )
   }
@@ -70,4 +72,4 @@ export const DrawResult = ({ slug }: DrawResultProps) => {
   )
 }
 
-export default DrawResult
+export default withTranslation()(DrawResult)

--- a/src/components/DrawResult/ResultPhrase/ResultPhrase.tsx
+++ b/src/components/DrawResult/ResultPhrase/ResultPhrase.tsx
@@ -1,5 +1,6 @@
 import classname from 'classnames'
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import styles from './ResultPhrase.module.css'
 import globalStyles from '../../styles.module.css'
@@ -9,7 +10,7 @@ interface ResultPhraseProps {
   hidden: boolean
 }
 
-const ResultPhrase = ({ value, hidden }: ResultPhraseProps) => {
+const ResultPhrase: React.FC<WithTranslation & ResultPhraseProps> = ({ t, value, hidden }) => {
   if (!value) {
     return null
   }
@@ -19,9 +20,9 @@ const ResultPhrase = ({ value, hidden }: ResultPhraseProps) => {
       data-cy="ResultPhrase"
     >
       <p className="select-phrase">
-        <b data-cy="ResultPhrase_value">{value}</b> a été tiré(e) au sort&nbsp;!
+        <b data-cy="ResultPhrase_value">{value}</b> {t('result.selected_value')}
       </p>
     </div>
   )
 }
-export default ResultPhrase
+export default withTranslation()(ResultPhrase)

--- a/src/components/ImportValues/ImportValues.tsx
+++ b/src/components/ImportValues/ImportValues.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { Trans, WithTranslation, withTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './ImportValues.module.css'
@@ -9,13 +10,7 @@ import { RootState } from '../../store/store'
 import A from '../Shared/A/A'
 import Button from '../Shared/Button/Button'
 
-const placeholder = `Exemple :
-Margot
-Paul
-Richard
-Clémence`
-
-const ImportValues = () => {
+const ImportValues: React.FC<WithTranslation> = ({ t }) => {
   const router = useRouter()
   const values = useSelector((state: RootState) => state.draw.draw.values)
   const dispatch = useDispatch()
@@ -37,25 +32,22 @@ const ImportValues = () => {
   return (
     <div className={styles.container}>
       <div className={styles.explanations}>
-        <h2 className={styles.explanation1}>
-          Entrez les éléments à tirer au sort, séparés par des sauts à la ligne.
-        </h2>
-        <p>
-          Si vous importez depuis LibreOffice, OpenOffice ou Excel, copiez la colonne entière depuis
-          le tableur, et collez la ci-dessous.
-        </p>
+        <Trans
+          i18nKey="home.import_values.explanations"
+          components={{
+            Heading: <h2 className={styles.explanation1}>no content</h2>,
+            Paragraph: <p />,
+          }}
+        />
       </div>
       <textarea
         data-cy="ImportValues_importTextInput"
         className={styles.textarea}
         value={importText}
         onChange={handleTextareaChange}
-        placeholder={placeholder}
+        placeholder={t('home.import_values.placeholder')}
       />
-      <p>
-        {nbElements === 1 ? `${nbElements} élément détecté` : null}
-        {nbElements > 1 ? `${nbElements} éléments détectés` : null}
-      </p>
+      <p>{t('home.import_values.detected_elements', { count: nbElements })}</p>
       <p className={styles.submitContainer}>
         <Button
           color="blue"
@@ -63,13 +55,13 @@ const ImportValues = () => {
           onClick={handleSubmit}
           data-cy="ImportValues_submit"
         >
-          Importer
+          {t('home.import_values.submit_button')}
         </Button>
       </p>
       <p className={styles.cancelContainer} data-cy="ImportValues_cancel">
-        <A href="/">Annuler</A>
+        <A href="/">{t('home.import_values.cancel_button')}</A>
       </p>
     </div>
   )
 }
-export default ImportValues
+export default withTranslation()(ImportValues)

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,13 +1,14 @@
 import Link from 'next/link'
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import styles from './Footer.module.css'
 
-const Footer = () => (
+const Footer: React.FC<WithTranslation> = ({ t }) => (
   <footer className={styles.container}>
     <div className={styles.blueBackground}>
       <nav className={styles.nav}>
-        <Link href="/a-propos">À propos</Link>{' '}
+        <Link href="/a-propos">{t('footer.about')}</Link>{' '}
       </nav>
       <div className={styles.bottomLinks}>
         <a
@@ -22,9 +23,9 @@ const Footer = () => (
           href="https://paulintrognon.fr"
           target="_blank"
           rel="noopener noreferrer"
-          title="Site réalisé par Paulin Trognon"
+          title={t('footer.made_by')}
         >
-          Paulin Trognon {new Date().getFullYear()}
+          {t('footer.made_by_name')} {new Date().getFullYear()}
         </a>{' '}
         -{' '}
         <a
@@ -33,7 +34,7 @@ const Footer = () => (
           rel="noopener noreferrer"
         >
           <i className="fa fa-github" aria-hidden="true"></i>
-          &nbsp;Code source
+          &nbsp;{t('footer.code_source')}
         </a>{' '}
         -{' '}
         <a
@@ -42,10 +43,10 @@ const Footer = () => (
           rel="noopener noreferrer"
         >
           <i className="fa fa-bug" aria-hidden="true"></i>
-          &nbsp;Bugs &amp; suggestions
+          &nbsp;{t('footer.bugs_and_suggestions')}
         </a>
       </div>
     </div>
   </footer>
 )
-export default Footer
+export default withTranslation()(Footer)

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import Footer from './Footer'
 import Header from './Header/Header'
@@ -7,7 +8,7 @@ import styles from './Layout.module.css'
 interface LayoutProps {
   children: React.ReactNode
 }
-const Layout = ({ children }: LayoutProps) => (
+const Layout: React.FC<WithTranslation & LayoutProps> = ({ children, t }) => (
   <>
     <Head>
       <meta charSet="utf-8" />
@@ -20,15 +21,9 @@ const Layout = ({ children }: LayoutProps) => (
       <link rel="manifest" href="/manifest.webmanifest" />
       <link rel="shortcut icon" href="/favicon.ico" />
 
-      <title>Plouf, plouf ! Tirage au sort en ligne</title>
-      <meta
-        name="description"
-        content="Plouf plouf est un outil de tirage au sort en ligne avec partage du résultat. Tirage aléatoire parmi une liste de mots."
-      />
-      <meta
-        name="keywords"
-        content="plouf plouf, tirage au sort, tirer au sort, tirer au hasard,en ligne"
-      />
+      <title>{t('application.title')}</title>
+      <meta name="description" content={t('application.description')} />
+      <meta name="keywords" content={t('application.keywords')} />
       <link
         rel="stylesheet"
         href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
@@ -43,4 +38,4 @@ const Layout = ({ children }: LayoutProps) => (
     </div>
   </>
 )
-export default Layout
+export default withTranslation()(Layout)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,19 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+i18n.use(initReactI18next).init({
+  fallbackLng: 'fr',
+  debug: true,
+  load: 'languageOnly',
+  resources: {
+    fr: {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      translation: require('./locales/fr.yml').default.fr,
+    },
+  },
+  interpolation: {
+    escapeValue: false,
+  },
+})
+
+export default i18n

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -1,0 +1,144 @@
+fr:
+  application:
+    title: 'Plouf Plouf'
+    description: 'Plouf plouf est un outil de tirage au sort en ligne avec partage du résultat. Tirage aléatoire parmi une liste de mots.'
+    keywords: 'plouf plouf, tirage au sort, tirer au sort, tirer au hasard,en ligne'
+  about:
+    title: 'À Propos - Plouf Plouf, tirage au sort en ligne'
+    description: 'À propos de plouf-plouf: tirage au sort en ligne 100% gratuit, sans pub, dans le respect total des données personnelles.'
+    content_html: |
+      <Heading>À propos</Heading>
+      <Paragraph>
+        <Bold>http://plouf-plouf.fr</Bold> est un site entièrement gratuit, sans aucune pub ni aucun
+        tracking des utilisateurs. Les données du tirage au sort ne sont à aucun moment stockées sur
+        le serveur. En effet, lors du partage d'un tirage au sort, les données du tirage sont
+        stockées directement et uniquement dans l'URL générée.
+      </Paragraph>
+      <Paragraph>
+        <Bold>
+          Les données des tirages sont strictement confidentielles: ni les auteurs du site, ni
+          les hébergeurs du site n'y ont accès.
+        </Bold>
+      </Paragraph>
+      <Paragraph>
+        <Bold>
+          Si vous partagez le résultat d'un tirage au sort, alors toutes les personnes ayant
+          accès à l'URL du tirage auront accès à toutes les données du tirage.
+        </Bold>
+      </Paragraph>
+      <Paragraph>
+        Le site a entièrement été réalisé de manière bénévole par
+        <Link href='https://paulintrognon.fr'>Paulin Trognon</Link>.
+        Le code source du site est consultable à cette adresse:
+
+        <Link href='https://github.com/paulintrognon/plouf-plouf'>github.com/paulintrognon/plouf-plouf</Link>.
+      </Paragraph>
+      <Heading>Comment ça marche ?</Heading>
+      <Paragraph>
+        Les tirages sont effectuées en local, directement par le navigateur, à l'aide de la
+        méthode <Code>Math.random()</Code>.
+      </Paragraph>
+      <Paragraph>
+        Afin de pouvoir partager le tirage et son résultat, une URL est générée contenant les mots
+        ainsi que le résultat au format json, encodé en base 64.
+      </Paragraph>
+      <Paragraph>
+        Par exemple, pour l'URL
+        https://plouf-plouf.fr/r#eyJ2IjpbIlBhdWwiLCJNYXJnb3QiXSwiaSI6MX0=-v3, le tirage est encodé
+        dans <Code>eyJ2IjpbIlBhdWwiLCJNYXJnb3QiXSwiaSI6MX0=</Code>, qui une fois décodé donne:
+        <Code>{"v":["Paul","Margot"],"i":1}</Code>
+      </Paragraph>
+      <Heading>Conditions Générales d'Utilisation</Heading>
+      <Paragraph>
+        L'utilisation du site plouf-plouf.fr implique l'acceptation des conditions
+        générales d'utilisation (CGU) suivantes (CGU et mentions légales susceptibles de
+        modification à tout moment, les utilisateurs sont invités à les consulter à chaque
+        utilisation du site).
+      </Paragraph>
+      <Paragraph>
+        Le site plouf-plouf.fr est supposé accessible en tout instant, pour tous les utilisateurs
+        connectés au serveur, néanmoins des interruptions (volontaires : mise à jour, maintenance
+        technique, etc.) ou involontaires (problèmes hébergeurs, bugs, etc.) peuvent néanmoins
+        survenir.
+      </Paragraph>
+      <Paragraph>
+        Le site plouf-plouf.fr est un site composé d'un formulaire ayant pour but de générer un
+        tirage au sort. Toutefois, les auteurs ne pourront être tenus responsables
+        d'éventuelles omissions ou inexactitudes dans les résultats et informations fournis.
+        Les données et informations qui peuvent êtres consultées sur le site plouf-plouf.fr évoluent
+        régulièrement et ne peuvent être considérées comme fiables dans le temps.
+      </Paragraph>
+      <Paragraph>
+        Le site plouf-plouf.fr utilise des technologies web standard (HTML, CSS, JavaScript) et ne
+        pourra être tenu responsable de dommages directs ou indirects liés à l'usage du site.
+        L'utilisateur s'engage à utiliser le site plouf-plouf.fr uniquement avec un
+        matériel récent et des logiciels mis à jour et non modifiés (piratage, virus, etc.). En
+        utilisant le site plouf-plouf.fr, l'hébergeur a l'obligation de recueillir
+        certaines données comme l'adresse IP de l'utilisateur. Noter qu'aucune
+        requête directe demandant nom, prénom, adresse, ou autres données personnelles identifiantes
+        ne sera réalisée sur le site plouf-plouf.fr. Néanmoins, pour certains services proposés par
+        plouf-plouf.fr, l'utilisateur doit rester attentif à ne pas fournir ce type
+        d'informations notamment lorsqu'il procède par lui-même à leur saisie. Le site
+        plouf-plouf.fr propose des liens vers d'autres sites mais n'a pas la capacité de
+        vérifier les contenus mis à jour des sites ainsi visités, et ne pourra être tenu responsable
+        de leur contenu.
+      </Paragraph>
+  home:
+    import_values:
+      explanations: |
+        <Heading>
+          Entrez les éléments à tirer au sort, séparés par des sauts à la ligne.
+        </Heading>
+        <Paragraph>
+          Si vous importez depuis LibreOffice, OpenOffice ou Excel, copiez la colonne entière depuis
+          le tableur, et collez la ci-dessous.
+        </Paragraph>
+      placeholder: |
+        Exemple :
+        Margot
+        Paul
+        Richard
+        Clémence
+      submit_button: 'Importer'
+      cancel_button: 'Annuler'
+      detected_elements_one: '{{count}} élément détecté'
+      detected_elements_other: '{{count}} éléments détectés'
+    form:
+      add_element:
+        placeholder: 'Ex: Paul [↵] Margot [↵]'
+        title: 'Entrez ici un mot ou un nom à tirer au sort.'
+        button_title: 'Cliquez ici pour ajouter une valeur à la liste'
+        help_text: 'Ajoutez plusieurs éléments à tirer au sort, puis cliquez sur "Tirer au sort".'
+        button_help_text: 'Pour ajouter un élément, inscrivez-le ci-dessus puis cliquez sur le bouton [+] ou sur la touche Entrée'
+      reset_button:
+        title: 'Cliquer ici pour recommencer un nouveau tirage de zéro.'
+        text: 'Tout supprimer'
+        confirm: 'Êtes-vous sûr de vouloir tout supprimer ?'
+      submit_button:
+        error_message: 'Vous devez inscrire au moins deux valeurs avant de pouvoir tirer au sort.'
+        success_message: 'Lancer le tirage au sort !'
+        text: 'Tirer au sort'
+    or: 'ou'
+    bulk_add_link: |
+      Importer une liste
+
+  result:
+    title: 'Plouf Plouf: résultat de votre tirage au sort'
+    description: 'Résultat de votre tirage au sort sur plouf-plouf.fr'
+    action_buttons:
+      share: 'Partager le résultat:'
+      modify: 'Modifier'
+      redo: 'Refaire'
+      redo_without_value: 'Refaire sans "{{value}}"'
+    selected_value: 'a été tiré(e) au sort'
+    animated_values:
+      no_values: 'Pas de valeurs.'
+    loading_error: 'Impossible de charger le tirage au sort à partir de cette url...'
+
+  footer:
+    about: 'À propos'
+    made_by: 'Site réalisé par Paulin Trognon'
+    made_by_name: 'Paulin Trognon'
+    code_source: 'Code source'
+    bugs_and_suggestions: 'Bugs & suggestions'
+    copyleft: 'Copyleft'

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,11 @@
 import { AppProps } from 'next/app'
 import Router from 'next/router'
 import React from 'react'
+import { I18nextProvider } from 'react-i18next'
 import { Provider } from 'react-redux'
-import '../styles.css'
 
+import '../styles.css'
+import i18n from '../i18n'
 import { store } from '../store/store'
 
 Router.events.on('routeChangeComplete', () => {
@@ -13,7 +15,9 @@ Router.events.on('routeChangeComplete', () => {
 // This default export is required in a new `pages/_app.js` file.
 const App = ({ Component, pageProps }: AppProps) => (
   <Provider store={store}>
-    <Component {...pageProps} />
+    <I18nextProvider i18n={i18n} defaultNS={'translation'}>
+      <Component {...pageProps} />
+    </I18nextProvider>
   </Provider>
 )
 

--- a/src/pages/a-propos.tsx
+++ b/src/pages/a-propos.tsx
@@ -1,19 +1,17 @@
 import Head from 'next/head'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import About from '../components/About/About'
 import Layout from '../components/Layout/Layout'
 
-const ImportPage = () => (
+const ImportPage: React.FC<WithTranslation> = ({ t }) => (
   <Layout>
     <Head>
-      <title>À Propos - Plouf Plouf, tirage au sort en ligne</title>
-      <meta
-        name="description"
-        content="À propos de plouf-plouf : tirage au sort en ligne 100% gratuit, sans pub, dans le respect total des données personnelles."
-      />
+      <title>{t('about.title')}</title>
+      <meta name="description" content={t('about.description')} />
     </Head>
     <About />
   </Layout>
 )
 
-export default ImportPage
+export default withTranslation()(ImportPage)

--- a/src/pages/r.tsx
+++ b/src/pages/r.tsx
@@ -1,18 +1,20 @@
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React from 'react'
+import { WithTranslation, withTranslation } from 'react-i18next'
 
 import DrawResult from '../components/DrawResult/DrawResult'
 import Layout from '../components/Layout/Layout'
 
-const DrawPage = () => {
+const DrawPage: React.FC<WithTranslation> = ({ t }) => {
   const router = useRouter()
   const slug = router.asPath.slice(3)
 
   return (
     <Layout>
       <Head>
-        <title>Plouf Plouf&nbsp;: résultat de votre tirage au sort</title>
+        <title>{t('result.title')}</title>
+        <meta name="description" content={t('result.description')} />
         <meta name="robots" content="noindex" />
       </Head>
       <DrawResult slug={slug} />
@@ -20,4 +22,4 @@ const DrawPage = () => {
   )
 }
 
-export default DrawPage
+export default withTranslation()(DrawPage)

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,6 +901,11 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.27.6":
+  version "7.27.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
+  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
+
 "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
@@ -3560,6 +3565,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 http-signature@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.4.0.tgz#dee5a9ba2bf49416abc544abd6d967f6a94c8c3f"
@@ -3588,6 +3600,20 @@ husky@9.1.6:
   version "9.1.6"
   resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
   integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
+
+i18next-browser-languagedetector@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz#c3ca311e249d2f7d8bb9b3b13ac9af380a3b15b0"
+  integrity sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^25.3.2:
+  version "25.3.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-25.3.2.tgz#3d6a7d1dc058caa1b9bdca47fd585483e2e7a637"
+  integrity sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==
+  dependencies:
+    "@babel/runtime" "^7.27.6"
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -3963,6 +3989,11 @@ jackspeak@^2.3.5:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+javascript-stringify@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-2.1.0.tgz#27c76539be14d8bd128219a2d731b09337904e79"
+  integrity sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==
+
 jest-worker@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
@@ -4046,7 +4077,7 @@ json5@^1.0.1, json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.3:
+json5@^2.1.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -4174,6 +4205,15 @@ loader-utils@^1.2.3:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -4904,6 +4944,14 @@ react-dom@18.3.1:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
+
+react-i18next@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-15.6.0.tgz#f1705587621bd3cc1c92af0145949cdad8fd2e15"
+  integrity sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==
+  dependencies:
+    "@babel/runtime" "^7.27.6"
+    html-parse-stringify "^3.0.1"
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -6016,6 +6064,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
+
 wait-on@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.1.tgz#13c8ec77115517f8fbc2d670521a444201f03f53"
@@ -6322,6 +6375,20 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml-loader@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/yaml-loader/-/yaml-loader-0.8.1.tgz#034f901147073cfc307cdcce8bd44c1547e60ba1"
+  integrity sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==
+  dependencies:
+    javascript-stringify "^2.0.1"
+    loader-utils "^2.0.0"
+    yaml "^2.0.0"
+
+yaml@^2.0.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
 yaml@~2.5.0:
   version "2.5.1"


### PR DESCRIPTION
Hi, 
This PR move all hard-coded french string in a `fr.yml` file. We used here the i18next-react library, with some simple setup: 

- load a yml file
- require statically the file to avoid extra http call
- use `<Trans>` component to have big content like About content that is html safe.
related to #64 

**Notes**

1. I had a recursive error when accessing the result loading error as the `useEffect` was somehow going in an infinite loop. see `src/components/DrawResult/DrawResult.tsx` @ useEffect changes 
2. I did a lint-ignore while requiring the `fr.yml` file, as `import` won't work on a yml file (I did add a `yaml-loader` for webpack). It might not be the best code I've done today haha. 

Thanks, 
