### PR TITLE
ci: gate publish on CI, dedup PR runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,11 @@
 name: CI
 on:
-  push:
-    paths:
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '**.ts'
-      - '**.tsx'
-      - '**.js'
-      - '**.json'
-      - '**.yaml'
+  pull_request:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Lint and TypeScript checks

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
   build-and-push:
+    needs: ci
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ pnpm test
 ```
 pnpm start
 ```
+
+# CI/CD
+
+Deux workflows GitHub Actions :
+
+- **CI** (`.github/workflows/ci.yaml`) — lint, type-check et tests Cypress. Tourne sur chaque pull request.
+- **Publish** (`.github/workflows/publish.yaml`) — construit et pousse l'image Docker sur `ghcr.io`. Déclenché par un push de tag `v*`.
+
+Publish rejoue la CI en premier (`workflow_call`) : l'image n'est publiée que si la CI passe.
+
+Pour publier une nouvelle version :
+
+```shell
+# bump version dans package.json, merge la PR, puis :
+git tag v5.7.0
+git push origin v5.7.0
+```


### PR DESCRIPTION
  - CI now triggers on pull_request + workflow_call only
  - Publish re-runs CI via workflow_call before pushing image
  - Concurrency cancels in-flight runs on the same PR branch